### PR TITLE
2 Bug Fixes on GateList and Score

### DIFF
--- a/Soomla/Assets/Plugins/Soomla/Levelup/gates/GatesList.cs
+++ b/Soomla/Assets/Plugins/Soomla/Levelup/gates/GatesList.cs
@@ -58,7 +58,11 @@ namespace Soomla.Levelup
 		public GatesList(string id, List<Gate> gates)
 			: base(id)
 		{
-			Gates = gates;
+			// Iterate over gates in given list and add them to Gates making a 
+			// copy and attaching listeners
+			foreach (Gate gate in gates) {
+				Gates.Add(gate);
+			}
 		}
 		
 		/// <summary>

--- a/Soomla/Assets/Plugins/Soomla/Levelup/scoring/Score.cs
+++ b/Soomla/Assets/Plugins/Soomla/Levelup/scoring/Score.cs
@@ -135,7 +135,7 @@ namespace Soomla.Levelup {
 				ScoreStorage.SetLatestScore(this, _tempScore);
 
 				double record = ScoreStorage.GetRecordScore(this);
-				if (HasTempReached(record)) {
+				if (record == -1 || HasTempReached(record)) {
 					ScoreStorage.SetRecordScore(this, _tempScore);
 					_scoreRecordReachedSent = false;
 				}


### PR DESCRIPTION
Hi,

I have found 2 bugs while I was working with the Soomla and wanted to share my fixes.

First issue was with a particular GateList constructor. When adding Gate to a GateList via `gateList.Add(gate)`, GateList attaches listeners to detect changes in its child gates. This behaviour is not replicated in the `GatesList(string id, List<Gate> gates)` constructor. I amended this issue by manually adding the gates from the parameter list instead of replacing the initial list.

Second issue was with updating Record score. This problem was only visible with `higherIsBetter = false` scores. When if statement compares a higherIsBetter score default record value -1 is considered as the best score and record is not updated. Instead of making changes in `HasTempReached` I have added an or statement that ignores -1 scores completely and directly saves the score as a record score.

I loved Soomla so far and would love to use it again in the future. Keep up the good work :)

