### PR TITLE
Fixed exception in world.SumInnerWorldsRecords()

### DIFF
--- a/Soomla/Assets/Plugins/Soomla/Levelup/World.cs
+++ b/Soomla/Assets/Plugins/Soomla/Levelup/World.cs
@@ -355,17 +355,47 @@ namespace Soomla.Levelup {
 			return Scores.First().Value;
 		}
 
-		/// <summary>
-		/// Sums the inner <c>World</c> records.
-		/// </summary>
-		/// <returns>The sum of inner <c>World</c> records.</returns>
-		public double SumInnerWorldsRecords() {
-			double ret = 0;
-			foreach(World world in InnerWorldsList) {
-				ret += ( world.GetSingleScore() ?? new Score("DUMMY") ).Record;
-			}
-			return ret;
-		}
+        /// <summary>
+        /// Sums up this world's total <c>Score</c> value.
+        /// </summary>
+        /// <returns>The total world score.</returns>
+        public double SumWorldScoreRecords() {
+            return Scores.Sum( s => s.Value.Record );
+        }
+
+        /// <summary>
+        /// Sums the inner <c>World</c> records.
+        /// </summary>
+        /// <returns>The sum of inner <c>World</c> records.</returns>
+        [Obsolete( "This method is obsolete, use SumInnerWorldSingleRecords() instead." )]
+        public double SumInnerWorldsRecords() {
+            return SumInnerWorldSingleRecords();
+        }
+
+        /// <summary>
+        /// Sums the inner <c>World</c> single score records, non-recursive.
+        /// </summary>
+        /// <returns>The sum of inner <c>World</c> records.</returns>
+        public double SumInnerWorldSingleRecords() {
+            double ret = 0;
+            foreach( World world in InnerWorldsList ) {
+                ret += ( world.GetSingleScore() ?? new Score( "DUMMY" ) ).Record;
+            }
+            return ret;
+        }
+
+        /// <summary>
+        /// Sums up all the inner <c>World</c> records, recursively.
+        /// </summary>
+        /// <returns>The sum of inner <c>World</c> records.</returns>
+        public double SumAllInnerWorldsRecords() {
+            double ret = 0;
+            foreach( World world in InnerWorldsList ) {
+                ret += world.SumWorldScoreRecords();
+                ret += world.SumAllInnerWorldsRecords();
+            }
+            return ret;
+        }
 
 
 		/** For more than one Score **/

--- a/Soomla/Assets/Plugins/Soomla/Levelup/World.cs
+++ b/Soomla/Assets/Plugins/Soomla/Levelup/World.cs
@@ -362,7 +362,7 @@ namespace Soomla.Levelup {
 		public double SumInnerWorldsRecords() {
 			double ret = 0;
 			foreach(World world in InnerWorldsList) {
-				ret += world.GetSingleScore().Record;
+				ret += ( world.GetSingleScore() ?? new Score("DUMMY") ).Record;
 			}
 			return ret;
 		}


### PR DESCRIPTION
Fixed issue where calling world.SumInnerWorldsRecords() will result in a NullReferenceException if any level of the hierarchy doesn't contain a score.

Opted for an in-place dummy rather than letting GetSingleScore return a dummy or anything like that, as it may have other side-effects from other callers. 

I also think that SumInnerWorldsRecords() is a misleading name, as it's sounds like it would sum up all records of inner worlds, rather than the "single" score (which also is a misleading and useless concept IMHO, but never mind). It also isn't recursive. 

The second and third commits contains an extension to this and a clarification (used deprecation rather than renaming the method for backward compatability reasons). This is more of a suggestion of what I find very useful myself, do your own implementation if you prefer.