### PR TITLE
Fixed bug where android storage returns -1 if not yet stored once

### DIFF
--- a/Soomla/Assets/Plugins/Soomla/Levelup/World.cs
+++ b/Soomla/Assets/Plugins/Soomla/Levelup/World.cs
@@ -360,7 +360,7 @@ namespace Soomla.Levelup {
         /// </summary>
         /// <returns>The total world score.</returns>
         public double SumWorldScoreRecords() {
-            return Scores.Sum( s => s.Value.Record );
+            return Scores.Select( s => s.Value.Record <= s.Value.StartValue ? s.Value.StartValue : s.Value.Record ).Sum( s => s );
         }
 
         /// <summary>


### PR DESCRIPTION
Since this is valid in some cases, sum of all records checks against the initial value of the Score to make sure it is at least that high.

Please be aware that any score read using the Android implementation of score storage will have this problem, which I as a user of the framework find very confusing. It causes subtle bugs that might be hard to track down. Perhaps consider always returning at least startvalue?